### PR TITLE
Generated options

### DIFF
--- a/inc/class-stream-papertrail-api.php
+++ b/inc/class-stream-papertrail-api.php
@@ -79,7 +79,7 @@ class Stream_Papertrail_API {
 			$record['meta']['user_meta'] = unserialize( $record['meta']['user_meta'] );
 		}
 
-		$this->send_remote_syslog( json_encode( $record ) );
+		$this->send_remote_syslog( $record );
 
 	}
 
@@ -91,6 +91,11 @@ class Stream_Papertrail_API {
 		$destination = array_combine( array( 'hostname', 'port' ), explode( ':', $this->options['papertrail_destination'] ) );
 		$program     = $this->options['papertrail_program'];
 		$component   = $this->options['papertrail_component'];
+
+		$program     = parse_url( is_multisite() ? network_site_url() : site_url(), PHP_URL_HOST );
+		$component   = sanitize_title( 'stream-' . $message['connector'] );
+
+		$message = json_encode( $message );
 
 		$syslog_message = '<22>' . date( 'M d H:i:s ' ) . $program . ' ' . $component . ': ' . $this->format( $message );
 

--- a/inc/class-stream-papertrail-api.php
+++ b/inc/class-stream-papertrail-api.php
@@ -37,20 +37,6 @@ class Stream_Papertrail_API {
 					'default'     => '',
 				),
 				array(
-					'name'        => 'program',
-					'title'       => esc_html__( 'Program', 'stream-papertrail' ),
-					'type'        => 'text',
-					'desc'        => esc_html__( '', 'stream-papertrail' ),
-					'default'     => 'wordpress',
-				),
-				array(
-					'name'        => 'component',
-					'title'       => esc_html__( 'Component', 'stream-papertrail' ),
-					'type'        => 'text',
-					'desc'        => esc_html__( '', 'stream-papertrail' ),
-					'default'     => 'stream',
-				),
-				array(
 					'name'        => 'enable_colorization',
 					'title'       => esc_html__( 'Colorization', 'stream-papertrail' ),
 					'type'        => 'checkbox',
@@ -89,8 +75,6 @@ class Stream_Papertrail_API {
 	public function send_remote_syslog( $message, $component = 'stream', $program = 'wordpress' ) {
 
 		$destination = array_combine( array( 'hostname', 'port' ), explode( ':', $this->options['papertrail_destination'] ) );
-		$program     = $this->options['papertrail_program'];
-		$component   = $this->options['papertrail_component'];
 
 		$program     = parse_url( is_multisite() ? network_site_url() : site_url(), PHP_URL_HOST );
 		$component   = sanitize_title( 'stream-' . $message['connector'] );


### PR DESCRIPTION
Plugin now automatically sets the `program` and `component` values to the hostname and `stream-` plus the connector name respectively.

Resolves #11, unless someone comes up with a better approach.

<img width="1280" alt="screen shot 2015-09-08 at 23 45 21" src="https://cloud.githubusercontent.com/assets/237905/9736309/bbbdaad4-5683-11e5-82b0-eb76bf568068.png">
